### PR TITLE
Add Drizzle ORM Schema

### DIFF
--- a/drizzle/0001_far_mystique.sql
+++ b/drizzle/0001_far_mystique.sql
@@ -1,0 +1,11 @@
+ALTER TABLE "users" ALTER COLUMN "id" SET DATA TYPE serial;--> statement-breakpoint
+ALTER TABLE "users" ALTER COLUMN "id" DROP IDENTITY;--> statement-breakpoint
+ALTER TABLE "users" ADD COLUMN "full_name" text NOT NULL;--> statement-breakpoint
+ALTER TABLE "users" ADD COLUMN "username" varchar(50) NOT NULL;--> statement-breakpoint
+ALTER TABLE "users" ADD COLUMN "email" text NOT NULL;--> statement-breakpoint
+ALTER TABLE "users" ADD COLUMN "password_hash" text NOT NULL;--> statement-breakpoint
+ALTER TABLE "users" ADD COLUMN "avatar_url" text;--> statement-breakpoint
+ALTER TABLE "users" ADD COLUMN "created_at" timestamp DEFAULT now() NOT NULL;--> statement-breakpoint
+ALTER TABLE "users" DROP COLUMN "name";--> statement-breakpoint
+ALTER TABLE "users" ADD CONSTRAINT "users_username_unique" UNIQUE("username");--> statement-breakpoint
+ALTER TABLE "users" ADD CONSTRAINT "users_email_unique" UNIQUE("email");

--- a/drizzle/0002_silent_trish_tilby.sql
+++ b/drizzle/0002_silent_trish_tilby.sql
@@ -1,0 +1,2 @@
+ALTER TABLE "users" DROP CONSTRAINT "users_username_unique";--> statement-breakpoint
+ALTER TABLE "users" DROP COLUMN "username";

--- a/drizzle/meta/0001_snapshot.json
+++ b/drizzle/meta/0001_snapshot.json
@@ -1,0 +1,90 @@
+{
+  "id": "139899d3-975f-4264-a773-7c54bc8b5a17",
+  "prevId": "2ec305ae-ecf2-42bc-8ae8-b5e239356048",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "full_name": {
+          "name": "full_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "username": {
+          "name": "username",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_username_unique": {
+          "name": "users_username_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "username"
+          ]
+        },
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/0002_snapshot.json
+++ b/drizzle/meta/0002_snapshot.json
@@ -1,0 +1,77 @@
+{
+  "id": "cfcf86d7-bba5-4386-8bc1-4e69081ca59c",
+  "prevId": "139899d3-975f-4264-a773-7c54bc8b5a17",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "full_name": {
+          "name": "full_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -8,6 +8,13 @@
       "when": 1736869600416,
       "tag": "0000_deep_ultimatum",
       "breakpoints": true
+    },
+    {
+      "idx": 1,
+      "version": "7",
+      "when": 1738331167793,
+      "tag": "0001_far_mystique",
+      "breakpoints": true
     }
   ]
 }

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -15,6 +15,13 @@
       "when": 1738331167793,
       "tag": "0001_far_mystique",
       "breakpoints": true
+    },
+    {
+      "idx": 2,
+      "version": "7",
+      "when": 1738337508433,
+      "tag": "0002_silent_trish_tilby",
+      "breakpoints": true
     }
   ]
 }

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -1,6 +1,11 @@
-import { integer, pgTable, varchar } from "drizzle-orm/pg-core";
+import { pgTable, varchar, serial, timestamp, text } from "drizzle-orm/pg-core";
 
 export const usersTable = pgTable("users", {
-  id: integer().primaryKey().generatedAlwaysAsIdentity(),
-  name: varchar({ length: 255 }).notNull(),
+  id: serial("id").primaryKey(),
+  fullName: text("full_name").notNull(),
+  username: varchar("username", {length: 50}).notNull().unique(),
+  email: text("email").notNull().unique(),
+  passwordHash: text("password_hash").notNull(),
+  avatarUrl: text("avatar_url"),
+  createdAt: timestamp("created_at").notNull().defaultNow(),
 });

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -3,7 +3,6 @@ import { pgTable, varchar, serial, timestamp, text } from "drizzle-orm/pg-core";
 export const usersTable = pgTable("users", {
   id: serial("id").primaryKey(),
   fullName: text("full_name").notNull(),
-  username: varchar("username", {length: 50}).notNull().unique(),
   email: text("email").notNull().unique(),
   passwordHash: text("password_hash").notNull(),
   avatarUrl: text("avatar_url"),


### PR DESCRIPTION
This PR integrates Drizzle ORM with PostgreSQL for the project and sets up the necessary migrations. It includes:

- A users table schema with fields: id, fullName, username, email, passwordHash, avatar, and createdAt.
- Ensures unique constraints on username and email.
- Adds a createdAt field with default timestamp for user creation tracking.
- Ran migrations using Neon Tech's PostgreSQL database service to apply the schema changes.